### PR TITLE
Fix imports to use bundled GaitCore package

### DIFF
--- a/Vicon/Devices/Accel.py
+++ b/Vicon/Devices/Accel.py
@@ -44,7 +44,7 @@
 # //==============================================================================
 
 from . import Devices
-from GaitCore.Core import PointArray
+from Vicon.GaitCore.Core import PointArray
 
 
 class Accel(Devices.Devices):

--- a/Vicon/Devices/EMG.py
+++ b/Vicon/Devices/EMG.py
@@ -44,7 +44,7 @@
 # //==============================================================================
 
 from . import Devices
-from GaitCore.Core import PointArray
+from Vicon.GaitCore.Core import PointArray
 
 class EMG(Devices.Devices):
 

--- a/Vicon/Devices/ForcePlate.py
+++ b/Vicon/Devices/ForcePlate.py
@@ -45,8 +45,8 @@
 
 
 from . import Devices
-from GaitCore.Core import PointArray
-from GaitCore.Core import Newton
+from Vicon.GaitCore.Core import PointArray
+from Vicon.GaitCore.Core import Newton
 
 class ForcePlate(Devices.Devices):
 

--- a/Vicon/Devices/Gyro.py
+++ b/Vicon/Devices/Gyro.py
@@ -44,7 +44,7 @@
 # //==============================================================================
 
 from . import Devices
-from GaitCore.Core import PointArray
+from Vicon.GaitCore.Core import PointArray
 
 
 class Gyro(Devices.Devices):

--- a/Vicon/Devices/IMU.py
+++ b/Vicon/Devices/IMU.py
@@ -44,7 +44,7 @@
 # //==============================================================================
 
 from . import Devices
-from GaitCore.Core import PointArray
+from Vicon.GaitCore.Core import PointArray
 
 class IMU(Devices.Devices):
 

--- a/Vicon/Examples/example.py
+++ b/Vicon/Examples/example.py
@@ -45,7 +45,7 @@
 
 
 import numpy as np
-import GaitCore.Core as core
+from Vicon.GaitCore import Core as core
 from Vicon.Mocap import Vicon
 from Vicon import Markers
 import matplotlib.pyplot as plt

--- a/Vicon/GaitCore/Bio/Joint.py
+++ b/Vicon/GaitCore/Bio/Joint.py
@@ -43,9 +43,9 @@
 # */
 # //==============================================================================
 
-from GaitCore.Bio.Sara import Sara
-from GaitCore.Bio.Score import Score
-from GaitCore.Core.Angle import Angle
+from .Sara import Sara
+from .Score import Score
+from ..Core.Angle import Angle
 
 
 class Joint():

--- a/Vicon/GaitCore/Bio/Sara.py
+++ b/Vicon/GaitCore/Bio/Sara.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import itertools
-from GaitCore import Core as core
+from .. import Core as core
 class Sara:
 
     def __init__(self, sara_data):

--- a/Vicon/GaitCore/Bio/Score.py
+++ b/Vicon/GaitCore/Bio/Score.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import itertools
-from GaitCore import Core as core
+from .. import Core as core
 class Score:
 
     def __init__(self, score_data):

--- a/Vicon/GaitCore/Core/PointArray.py
+++ b/Vicon/GaitCore/Core/PointArray.py
@@ -46,7 +46,7 @@
 # //==============================================================================
 
 
-import GaitCore.Core.Point as Point
+from . import Point
 import numpy as np
 
 class PointArray():

--- a/Vicon/Markers/ModelOutput.py
+++ b/Vicon/Markers/ModelOutput.py
@@ -46,16 +46,15 @@
 
 import copy
 
-from GaitCore import Core as core
-from GaitCore.Bio.Sara import Sara
-from GaitCore.Bio.Score import Score
-from GaitCore.Bio.Joint import Joint
-from GaitCore.Core.Angle import Angle
+from Vicon.GaitCore import Core as core
+from Vicon.GaitCore.Bio.Sara import Sara
+from Vicon.GaitCore.Bio.Score import Score
+from Vicon.GaitCore.Bio.Joint import Joint
+from Vicon.GaitCore.Core.Angle import Angle
 
-from GaitCore.Bio.Leg import Leg
-from GaitCore.Bio.Arm import Arm
-from GaitCore.Bio.Trunk import Trunk
-from GaitCore.Bio.Joint import Joint
+from Vicon.GaitCore.Bio.Leg import Leg
+from Vicon.GaitCore.Bio.Arm import Arm
+from Vicon.GaitCore.Bio.Trunk import Trunk
 
 
 class ModelOutput():

--- a/Vicon/Mocap/Vicon.py
+++ b/Vicon/Mocap/Vicon.py
@@ -45,7 +45,7 @@
 import csv
 from typing import List, Any
 import numpy as np
-from GaitCore.Bio.Joint import Joint
+from Vicon.GaitCore.Bio.Joint import Joint
 from Vicon.Interpolation import Akmia
 from Vicon.Markers import ModelOutput as modeloutput
 from Vicon.Devices import EMG, IMU, Accel, ForcePlate

--- a/Vicon/Tools/AnimateModel.py
+++ b/Vicon/Tools/AnimateModel.py
@@ -4,9 +4,9 @@ import matplotlib.pyplot as plot
 import matplotlib.animation as animation
 from mpl_toolkits.mplot3d import Axes3D as plot3d
 
-from GaitCore.Core.PointArray import PointArray
-from GaitCore.Bio.Sara import Sara
-from GaitCore.Bio.Score import Score
+from Vicon.GaitCore.Core.PointArray import PointArray
+from Vicon.GaitCore.Bio.Sara import Sara
+from Vicon.GaitCore.Bio.Score import Score
 
 class AnimateModel():
     def __init__(self,  window_title: str = "3D Marker Animation",


### PR DESCRIPTION
## Summary
- update Vicon reader modules to import GaitCore resources from the bundled package namespace
- switch internal GaitCore modules to use relative imports so they resolve correctly without the external package

## Testing
- python -m compileall Vicon

------
https://chatgpt.com/codex/tasks/task_e_68d89630eb2c8321959aafcc18cc6dad
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix imports to use bundled `GaitCore` package and switch to relative imports for internal modules.
> 
>   - **Imports**:
>     - Update imports in `Vicon/Devices/Accel.py`, `Vicon/Devices/EMG.py`, and `Vicon/Devices/ForcePlate.py` to use `Vicon.GaitCore` namespace.
>     - Change `GaitCore.Core` import to `Vicon.GaitCore.Core` in `Vicon/Examples/example.py`.
>     - Modify imports in `Vicon/Markers/ModelOutput.py` to use `Vicon.GaitCore` namespace.
>   - **Relative Imports**:
>     - Switch to relative imports in `Vicon/GaitCore/Bio/Joint.py`, `Vicon/GaitCore/Bio/Sara.py`, and `Vicon/GaitCore/Bio/Score.py`.
>     - Use relative import for `Point` in `Vicon/GaitCore/Core/PointArray.py`.
>   - **Testing**:
>     - Verified changes using `python -m compileall Vicon`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RTnhN%2FViconReader&utm_source=github&utm_medium=referral)<sup> for 49bae51882a68f645255215cdc13de69178c10fb. You can [customize](https://app.ellipsis.dev/RTnhN/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->